### PR TITLE
Fix dependency issue in workflow

### DIFF
--- a/.github/workflows/build-examples.yml
+++ b/.github/workflows/build-examples.yml
@@ -16,7 +16,9 @@ jobs:
         uses: actions/checkout@v2
       # Install the venv module 
       - name: Install dependencies
-        run: apt install python3-venv
+        run: |
+          apt-get update -y 
+          apt-get install -y python3-venv
       # Run the fota build tool with mock as the option
       - name: Build example
         run: ./scripts/fota.sh -e=mock
@@ -30,7 +32,9 @@ jobs:
         uses: actions/checkout@v2
       # jq is a command-line JSON processor
       - name: Install dependencies
-        run: apt-get install jq && apt install python3-venv
+        run: | 
+          apt-get update -y
+          apt-get install -y jq python3-venv
       # Pipe "yes" into the script to select the appropriate option
       # More information about this in the documentation
       # Run the fota build tool with mcuboot as the option

--- a/.github/workflows/build-examples.yml
+++ b/.github/workflows/build-examples.yml
@@ -9,6 +9,7 @@ on:
 jobs:
   build-mock:
     runs-on: ubuntu-latest
+    container: mbedos/mbed-os-env:latest
     steps:
       # Checkout the repo and download it to the runner
       - name: Checkout
@@ -19,6 +20,7 @@ jobs:
 
   build-mcuboot:
     runs-on: ubuntu-latest
+    container: mbedos/mbed-os-env:latest
     steps:
       # Checkout the repo and download it to the runner
       - name: Checkout

--- a/.github/workflows/build-examples.yml
+++ b/.github/workflows/build-examples.yml
@@ -14,6 +14,9 @@ jobs:
       # Checkout the repo and download it to the runner
       - name: Checkout
         uses: actions/checkout@v2
+      # Install the venv module 
+      - name: Install dependencies
+        run: apt install python3-venv
       # Run the fota build tool with mock as the option
       - name: Build example
         run: ./scripts/fota.sh -e=mock
@@ -26,8 +29,8 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v2
       # jq is a command-line JSON processor
-      - name: Install jq
-        run: sudo apt-get install jq
+      - name: Install dependencies
+        run: apt-get install jq && apt install python3-venv
       # Pipe "yes" into the script to select the appropriate option
       # More information about this in the documentation
       # Run the fota build tool with mcuboot as the option


### PR DESCRIPTION
The workflow now uses the `mbed-os-env` docker container, which bundles the GCC ARM toolchain along with Python and CMake.

> **Note**: This pull request is a result of a pre-mature merge of #6. Furthermore, #7 was issued to fix `main` (i.e. restore it to the state before the merge).