### PR TITLE
Update documentation for examples

### DIFF
--- a/MCUboot/README.md
+++ b/MCUboot/README.md
@@ -1,163 +1,52 @@
-# FOTA service MCUboot example
+# MCUBoot Example
 
-This application extends the [Mock](../Mock) example by including a bootloader based on MCUboot.
+This demo application extends the [Mock](../Mock) example by including a bootloader based on [MCUboot](https://github.com/mcu-tools/mcuboot). 
 
-## Usage
+> **Note**: For more information on the MCUboot port for Mbed™ OS, please click [here](https://mcu-tools.github.io/mcuboot/readme-mbed.html). And, click [here](https://github.com/AGlass0fMilk/mbed-mcuboot-blinky) for an MCUboot/Mbed™ OS blinky example by [AGlassOfMilk](https://github.com/AGlass0fMilk).
 
-### Hardware requirements
-This application requires the [NRF52840_DK](https://os.mbed.com/platforms/Nordic-nRF52-DK/) platform.
+## Pre-requisites
 
-To use the Python client, the host PC must have Bluetooth capabilities, either through an inbuilt chipset or an external USB adapter.
+To use the Python client, the host computer must have Bluetooth capabilites, either through an inbuilt chipset or via an external USB adapter. This application requires the [NRF52840_DK](https://os.mbed.com/platforms/Nordic-nRF52840-DK/) platform to run; currently, the build tool only supports this platform. You will also need the [GNU ARM Embedded](https://developer.arm.com/tools-and-software/open-source-software/developer-tools/gnu-toolchain/gnu-rm) toolchain and `python3` in your path to build the example.
 
-### Build instructions
+> **Important**: For macOS users, your terminal emulator would have to be granted access to Bluetooth through `System Preferences > Security & Privacy > Pirvacy > Bluetooth`. Click on the padlock to make changes and check the box next to your terminal app. If the app is missing from the menu, click on the `+` icon to add your terminal app to the list.
 
-#### Setting up the environment
+If you chose to auto-update the `application/mbed_app.json` file, then the [jq](https://stedolan.github.io/jq/) command-line JSON processor is a required dependency that will need to be installed manually.
 
-1. Create a Python virtual environment inside the client folder:
+## Build
 
-   ```shell
-   cd client && mkdir venv && virtualenv venv && source venv/bin/activate && python -m pip install --upgrade pip
-   ```
-   
-1. Import the missing dependencies in the application and bootloader folders:
-   
-   ```shell
-   cd ../target/application && mbed deploy && cd ../bootloader && mbed deploy
-   ```
+To build the example, please run the following command from the repository root. To view more information on the steps involved in the build, please refer to the comments in [mcuboot.sh](../scripts/mcuboot.sh).
+```shell
+./scripts/fota.sh -e=mcuboot
+```
+> **Note**: You can build the example without a connected target board. The script indicates the location of the factory firmware and the update binary. The factory firmware would have to be flashed manually when the target board is indeed connected later. The update binary would be used in the demonstration stage.
 
-1. Install the Mbed OS and MCUboot requirements. 
-   Then, run the MCUboot setup script:
+## Demonstration
 
-   ```shell
-   pip install -r mbed-os/requirements.txt -r mcuboot/scripts/requirements.txt && python mcuboot/scripts/setup.py install
-   ```
+Please make sure to activate the virtual environment, located in the root folder, before proceeding further. Also, ensure that the target board is connected and has been flashed with the factory firmware from the build stage.
 
-1. Install mbed-cli, bleak and intelhex
-
-   ```shell
-   pip install mbed-cli bleak intelhex
-   ```
-
-#### Creating the signing keys and building the bootloader
-
-1. Generate a [RSA-2048](https://en.wikipedia.org/wiki/RSA_numbers#RSA-2048) key pair:
-
-   ```shell
-   mcuboot/scripts/imgtool.py keygen -k signing-keys.pem -t rsa-2048
-   ```
-
-1. Extract the public key into a C data structure so that it can be built into the bootloader:
-
-   ```shell
-   mcuboot/scripts/imgtool.py getpub -k signing-keys.pem >> signing_keys.c
-   ```
-
-1. Build the bootloader:
-
-   ```shell
-   mbed compile -t GCC_ARM -m NRF52840_DK
-   ```
-
-#### Building and signing the primary application
-
-1. Build the primary application:
-
-   ```shell
-   cd ../application && mbed compile -t GCC_ARM -m NRF52840_DK
-   ```
-
-1. Copy the HEX file into the bootloader folder:
-
-   ```shell
-   cp BUILD/NRF52840_DK/GCC_ARM/application.hex ../bootloader && cd ../bootloader
-   ```
-
-1. Sign the initial application using the rsa-2048 keys:
-
-   ```shell
-   mcuboot/scripts/imgtool.py sign -k signing-keys.pem --align 4 -v 0.1.0 --header-size 4096 --pad-header -S 0xC0000 --pad application.hex signed_application.hex
-   ```
-   
-#### Creating and flashing the "factory firmware"
-
-1. Merge the bootloader and signed application:
-
-   ```shell
-   hexmerge.py -o merged.hex --no-start-addr BUILD/NRF52840_DK/GCC_ARM/bootloader.hex signed_application.hex
-   ```
-
-1. Erase the chip:
-   
-   ```shell
-   pyocd erase --chip
-   ```
-   
-1. Flash the "factory firmware" onto the board by copying `merged.hex` over to its mount point:
-
-   ```shell
-   cp merged.hex <mount_point>
-   ```
-   
-   The target's mount point can be found by running `mbedls`.
-   
-#### Creating the update binary
-
-1. Change the application's version number in its [mbed_app.json](target/application/mbed_app.json) to 0.1.1 and rebuild it:
-
-   ```shell
-   cd ../application && mbed compile -t GCC_ARM -m NRF52840_DK
-   ```
-
-1. Copy the HEX file into the bootloader folder:
-
-   ```shell
-   cp BUILD/NRF52840_DK/GCC_ARM/application.hex ../bootloader && cd ../bootloader
-   ```
-
-1. Sign the update application using the rsa-2048 keys:
-
-   ```shell
-   mcuboot/scripts/imgtool.py sign -k signing-keys.pem --align 4 -v 0.1.1 --header-size 4096 --pad-header -S 0x55000 application.hex signed_update.hex
-   ```
-
-1. Generate a raw binary file from `signed_update.hex` so that it can be transported over BLE:
-
-   ```shell
-   arm-none-eabi-objcopy -I ihex -O binary signed_update.hex signed_update.bin
-   ```
-
-### Demonstration
-
-1. Open a serial terminal on the host PC to receive serial prints from the target:
-
+1. Open a serial terminal on the host computer to receive serial prints from the _FOTA target_:
    ```shell 
    mbed term -b 115200
    ```
-
-2. In a separate window, run the client script:
-
+2. In a separate shell window, run the test script from the client directory:
    ```shell
-   python client/client.py
+   python client.py
    ```
 
-   It scans for a device named 'FOTA' and attempts to connect to it.
+   It scans for a device named _"FOTA"_ and attempts to connect to it.
    Once connected, it asks the user to enter the path to the binary.
-   Enter the signed update binary:
+   Please enter the path to the signed update binary.
 
    ```
-   Enter the path to the binary: target/bootloader/signed_update.bin
+   Enter the path to the binary: ../target/bootloader/signed_update.bin
    ```
-   
    Note the firmware revision of the application running on the device:
-
    ```
    xxxx-xx-xx xx:xx:xx,xxx - logger - INFO - DFU Service found with firmware rev 0.1.0 for device "Primary MCU"
    ```
-   
-1. The client initiates the transfer once the FOTA session begins and commits the update once the entire binary has been sent.
+3. The client initiates the transfer once the FOTA session begins and commits the update once the entire binary has been sent.
    Subsequently, the target sets the update as pending and initiates a system reboot.
    Once the new application boots, the client reconnects and rereads the Firmware Revision Characteristic:
-   
    ```
    xxxx-xx-xx xx:xx:xx,xxx - logger - INFO - DFU Service found with firmware rev 0.1.1 for device "Primary MCU"
    ```

--- a/Mock/README.md
+++ b/Mock/README.md
@@ -1,92 +1,48 @@
-# FOTA service Mock example
+# Mock Example
 
-The FOTA service, as defined in its [specification](https://github.com/ARMmbed/mbed-os-experimental-ble-services/blob/fota-service-github-ci/services/FOTA/docs/README.md) document, facilitates the transfer of firmware updates over BLE.
+In this demo, the FOTA service is used to transfer a binary from the host PC into the flash of the target. A basic _FOTA client_, implemented in Python using [bleak](https://pypi.org/project/bleak/), is used to read/write the binary stream, control and status characteristics. 
 
-In this demo, the FOTA service is used to transfer a binary from the host PC into the flash of the target. 
-A basic _FOTA client_, implemented in Python using [bleak](https://pypi.org/project/bleak/), is used to read/write the binary stream, control and status characteristics. 
-Please refer to [Section 1](https://github.com/ARMmbed/mbed-os-experimental-ble-services/tree/fota-service-github-ci/services/FOTA/docs#fota-service-structure) of the spec to learn more about these characteristics.
+> **Note**: Please refer to the [FOTA Service Structure](https://github.com/ARMmbed/mbed-os-experimental-ble-services/tree/fota-service-github-ci/services/FOTA/docs#fota-service-structure) section of the service specification to learn more about these characteristics.
 
-To verify the success of the transfer, the application computes the [SHA-256](https://en.wikipedia.org/wiki/SHA-2) of the binary and prints it to the serial port.
-The SHA-256 is also computed on the host using [sha256sum](https://man7.org/linux/man-pages/man1/sha256sum.1.html).
-The transfer is regarded as a success if the hashes are equal.
+To verify the success of the transfer, the application computes the [SHA-256](https://en.wikipedia.org/wiki/SHA-2) of the binary and prints it to the serial port. The SHA-256 is also computed on the host using [sha256sum](https://man7.org/linux/man-pages/man1/sha256sum.1.html). The transfer is considered a success if the hashes are equal.
 
-## Usage
+## Pre-requisites
 
-### Hardware requirements
+To use the Python client, the host computer must have Bluetooth capabilites, either through an inbuilt chipset or via an external USB adapter. This application requires the [NRF52840_DK](https://os.mbed.com/platforms/Nordic-nRF52840-DK/) platform to run; currently, the build tool only supports this platform. You will also need the [GNU ARM Embedded](https://developer.arm.com/tools-and-software/open-source-software/developer-tools/gnu-toolchain/gnu-rm) toolchain and `python3` in your path to build the example.
 
-This application requires either the [DISCO_L475VG_IOT01A](https://os.mbed.com/platforms/ST-Discovery-L475E-IOT01A/) or [NRF52840_DK](https://os.mbed.com/platforms/Nordic-nRF52-DK/) platforms.
+> **Important**: For macOS users, your terminal emulator would have to be granted access to Bluetooth through `System Preferences > Security & Privacy > Pirvacy > Bluetooth`. Click on the padlock to make changes and check the box next to your terminal app. If the app is missing from the menu, click on the `+` icon to add your terminal app to the list.
 
-To use the Python client, the host PC must have Bluetooth capabilities, either through an inbuilt chipset or an external USB adapter.
+## Build 
 
-### Build instructions 
+To build the example, please run the following command from the repository root. To view more information on the steps involved in the build, please refer to the comments in [mock.sh](../scripts/mock.sh).
+```shell
+./scripts/fota.sh -e=mock
+```
+> **Note**: You can build the example without a connected target board. The script indicates the location of the flash binary at the end of the build; this binary would have to be flashed manually when the target board is indeed connected later.
 
-#### Setting up the environment
+## Demonstration
 
-1. Create a Python virtual environment inside the client folder:
+Please make sure to activate the virtual environment, located in the root folder, before proceeding further. Also, ensure that the target board is connected and has been flashed with the generated binary from the build stage.
 
-   ```shell
-   cd client && mkdir venv && virtualenv venv && source venv/bin/activate && python -m pip install --upgrade pip
-   ```
-
-1. Import the missing dependencies in the target folder:
-
-   ```shell
-   cd ../target && mbed-tools deploy
-   ```
-
-1. Install the Mbed OS requirements:
-
-   ```shell
-   pip install -r mbed-os/requirements.txt
-   ```
-
-1. Install mbed-tools and bleak:
-
-   ```shell
-   pip install mbed-cli bleak intelhex
-   ```
-
-#### Building the application
-
-1. The application can be built and flashed onto the target using Mbed CLI 2:
-
-   ```shell
-   mbed-tools compile -t <toolchain> -m <target> -f
-   ```
-
-1. A `bin` file is required for the demo. 
-   For nRF, this must be created manually from the `elf` as Mbed Tools outputs a `hex` file by default:
-
-   ```shell
-   arm-none-eabi-objcopy -O binary cmake_build/NRF52840_DK/develop/<toolchain>/BLE_GattServer_FOTAService.elf cmake_build/NRF52840_DK/develop/<toolchain>/BLE_GattServer_FOTAService.bin
-   ```
-
-### Demonstration
-
-1. Open a serial terminal on the host PC to receive serial prints from the _FOTA target_: 
-   
+1. Open a serial terminal on the host computer to receive serial prints from the _FOTA target_:
    ```shell 
    mbed term -b 115200
    ```
-
-1. In a separate window, run the test script: 
-   
-   ```
-   python client/client.py
+2. In a separate shell window, run the test script from the client directory:
+   ```shell
+   python client.py
    ```
    
-   It scans for a device named 'FOTA' and attempts to connect to it.
+   It scans for a device named _"FOTA"_ and attempts to connect to it.
    Once connected, it asks the user to enter the path to the binary.
-   Use the binary running on the target:
+   Use the binary already running on the target:
    
    ```
-   Enter the path to the binary: ../cmake_build/<target>/develop/<toolchain>/BLE_GattServer_FOTAService.bin
+   Enter the path to the binary: ../target/cmake_build/NRF52840_DK/develop/GCC_ARM/BLE_GattServer_FOTAService.bin
    ```
-   
-1. The client initiates the transfer once the FOTA session begins and commits the update once the entire binary has been sent.
+3. The client initiates the transfer once the FOTA session begins and commits the update once the entire binary has been sent.
    Subsequently, the target computes the SHA-256 of the binary and prints it to the serial.
    Verify the `<hash>` with sha256sum:
-   
    ```shell
    echo "<hash> ../cmake_build/<target>/develop/<toolchain>/BLE_GattServer_FOTAService.bin" | sha256sum --check
    ```

--- a/README.md
+++ b/README.md
@@ -7,10 +7,10 @@ This repository houses example applications built for the Arm® Mbed™ OS platf
 
 The examples come with _batteries included!_ They're bundled with an automated build tool, "fota.sh", that eases the build process for the end-user. Please refer to the sections below for more information.
 
-## 📝 Pre-requisites
+## Pre-requisites
 Currently, the only supported target board for the examples is the [`NRF52840_DK`](https://os.mbed.com/platforms/Nordic-nRF52840-DK/). Development work to support [`DISCO_L475VG_IOT01A`](https://os.mbed.com/platforms/ST-Discovery-L475E-IOT01A/) will commence soon. The [BLE documentation](https://os.mbed.com/docs/mbed-os/v6.12/apis/ble.html) describes the BLE APIs available on Mbed™ OS; going through this documentation isn't strictly essential to run the examples, but is helpful in understanding the sources.
 
-## 🛠 Build Tool
+## Build Tool
 The `fota.sh` cli tool aids in setup and build of the examples in this repository. The tool takes in as arguments the example, target board, mount point of the target board, and toolchain. Please run `./scripts/fota.sh --help` for usage instructions.
 
 > **Note**: If the mount point is not provided (it could be the case that an end-user is trying to build without the board connected), then the target binary is not flashed. This is especially useful for building the examples with a CI workflow.
@@ -19,11 +19,13 @@ The `fota.sh` cli tool aids in setup and build of the examples in this repositor
 >
 > **Important**: For now, the tool assumes the target board, toolchain, and example unless otherwise specified by the end-user. Currently, the only board and toolchain supported are `NRF52840_DK` and `GCC_ARM` respectively.
 
-## 📦 Examples
+## Examples
 
-🚧 _Section under construction..._ 🚧
+Please refer to the example-specific READMEs for build and demonstration instructions.
+1. [Mock Example](Mock)
+2. [MCUboot Example](MCUboot)
 
-## ☣️ Known Issues
+## Known Issues
 There are slight kludges with how the MCUboot and Mock examples are built with `fota.sh`. The former is a direct result of dependency conflicts between [mbed-tools](https://github.com/ARMmbed/mbed-tools), [pyocd](https://github.com/pyocd/pyOCD), and [mbed-os](https://github.com/ARMmbed/mbed-os). The latter is a result of issues with flashing the target binary to the connected board. The details of both are addressed below:
 
 1. **Dependency Conflicts**: The difference in version requirements of the [PyYAML](https://pyyaml.org) dependency imposed by both mbed-os and pyocd led to the creation of a temporary virtual environment; this is used in the "_creating and flashing the factory firmware_" stage of the MCUboot example build process. This is a known issue and would require changes to the `requirements.txt` file in the mbed-os to resolve.\
@@ -36,15 +38,15 @@ There are slight kludges with how the MCUboot and Mock examples are built with `
     ``` 
    The tool is looking for a hex file under the cmake build output whose name comes from project directory (in this case, "target"). However, the generated one is named `BLE_GattServer_FOTAService.hex`. Again, this is a known issue and has been [filed](https://github.com/ARMmbed/mbed-tools/issues/282) (282) in the mbed-tools repository by [noonfom](https://github.com/noonfom).
 
-## 📜 License
+## License
 The software in this repository is licensed under Apache-2.0. Please refer to [LICENSE](LICENSE) for more information. 
 
-## 🤝 Contributions
+## Contributions
 Mbed™ OS is an open-source, device software platform for the Internet of Things. Contributions are an important part of the platform, and our goal is to make it as simple as possible to become a contributor. Contributions to this repository are **greatly appreciated** and accepted under the same Apache-2.0 license. To encourage productive collaboration, as well as robust, consistent and maintainable code, we have a set of guidelines for [contributing to Mbed™ OS](https://os.mbed.com/docs/mbed-os/latest/contributing/index.html).
 
 > **Important**: Please target the `development` branch of this repository for pull requests.
 
-## 👀 Related
+## Related
 
 * [mbed-os-example-ble](https://github.com/ARMmbed/mbed-os-example-ble)
 * [mbed-os-experimental-ble-services](https://github.com/ARMmbed/mbed-os-experimental-ble-services)

--- a/README.md
+++ b/README.md
@@ -1,9 +1,51 @@
-# BLE FOTA Example
+# BLE FOTA Examples
 
-🚧 _Repository under construction..._ 🚧  
+[![Build Examples](https://github.com/ARMmbed/mbed-os-example-ble-fota/actions/workflows/build-examples.yml/badge.svg?branch=main)](https://github.com/ARMmbed/mbed-os-example-ble-fota/actions/workflows/build-examples.yml)
+[![License](https://img.shields.io/badge/License-Apache%202.0-blue.svg)](https://opensource.org/licenses/Apache-2.0)
 
-> __Note__: The contents of this repository are currently being migrated from the `fota-service-example` branch in the [mbed-os-example-ble](https://github.com/ARMmbed/mbed-os-example-ble) repository. 
+This repository houses example applications built for the Arm® Mbed™ OS platform that demonstrate the usage and abilities of the Bluetooth® Low Energy (BLE) firmware-over-the air (FOTA) service. The service specification and sources can be found [here](https://github.com/ARMmbed/mbed-os-experimental-ble-services/tree/fota-service-github-ci/services/FOTA). As defined in the specification, the FOTA service facilitates the transfer of firmware updates over BLE.
+
+The examples come with _batteries included!_ They're bundled with an automated build tool, "fota.sh", that eases the build process for the end-user. Please refer to the sections below for more information.
+
+## 📝 Pre-requisites
+Currently, the only supported target board for the examples is the [`NRF52840_DK`](https://os.mbed.com/platforms/Nordic-nRF52840-DK/). Development work to support [`DISCO_L475VG_IOT01A`](https://os.mbed.com/platforms/ST-Discovery-L475E-IOT01A/) will commence soon. The [BLE documentation](https://os.mbed.com/docs/mbed-os/v6.12/apis/ble.html) describes the BLE APIs available on Mbed™ OS; going through this documentation isn't strictly essential to run the examples, but is helpful in understanding the sources.
+
+## 🛠 Build Tool
+The `fota.sh` cli tool aids in setup and build of the examples in this repository. The tool takes in as arguments the example, target board, mount point of the target board, and toolchain. Please run `./scripts/fota.sh --help` for usage instructions.
+
+> **Note**: If the mount point is not provided (it could be the case that an end-user is trying to build without the board connected), then the target binary is not flashed. This is especially useful for building the examples with a CI workflow.
 >
-> To run the MCUBoot example, please refer to this [link](https://github.com/ARMmbed/mbed-os-example-ble/tree/fota-service-example/FOTA/MCUboot), and to run the Mock example, please refer to this [link](https://github.com/ARMmbed/mbed-os-example-ble/tree/fota-service-example/FOTA/Mock). The FOTA service specification overview can be found [here](https://github.com/ARMmbed/mbed-os-experimental-ble-services/blob/fota-service-github-ci/services/FOTA/docs/README.md).
+> In the case of the MCUboot example, the _"factory firmware"_ is saved and would require manual transfer when the board is indeed connected. In either case, the demonstration step would be the only part that requires manual intervention from the user.
 >
-> Please note that the documentation for these examples will be migrated soon to this repository (and may see some changes). 
+> **Important**: For now, the tool assumes the target board, toolchain, and example unless otherwise specified by the end-user. Currently, the only board and toolchain supported are `NRF52840_DK` and `GCC_ARM` respectively.
+
+## 📦 Examples
+
+🚧 _Section under construction..._ 🚧
+
+## ☣️ Known Issues
+There are slight kludges with how the MCUboot and Mock examples are built with `fota.sh`. The former is a direct result of dependency conflicts between [mbed-tools](https://github.com/ARMmbed/mbed-tools), [pyocd](https://github.com/pyocd/pyOCD), and [mbed-os](https://github.com/ARMmbed/mbed-os). The latter is a result of issues with flashing the target binary to the connected board. The details of both are addressed below:
+
+1. **Dependency Conflicts**: The difference in version requirements of the [PyYAML](https://pyyaml.org) dependency imposed by both mbed-os and pyocd led to the creation of a temporary virtual environment; this is used in the "_creating and flashing the factory firmware_" stage of the MCUboot example build process. This is a known issue and would require changes to the `requirements.txt` file in the mbed-os to resolve.\
+   \
+   Another minor conflict that doesn't hinder the build process is one between mbed-tools and mbed-os on the version requirement of the [Click](https://click.palletsprojects.com/en/8.0.x/) dependency; mbed-tools requires that the minimum version of Click to be greater than 7.1 while mbed-os requires it to be greater than 7.0. Now, the dependencies for mbed-os are installed after those of mbed-tools, which overwrites the newer version and generates a conflict. This would (again) require changes to the requirements file in the mbed-os repository to bump up the minimum version number of Click to 7.1.
+
+2. **Target Binary Flashing**: For the Mock example, compiling with mbed-tools results in the following error:
+    ```
+    ERROR: Build program file (firmware) not found <path to mock example>/target/cmake_build/<target board>/develop/<toolchain>/target.hex
+    ``` 
+   The tool is looking for a hex file under the cmake build output whose name comes from project directory (in this case, "target"). However, the generated one is named `BLE_GattServer_FOTAService.hex`. Again, this is a known issue and has been [filed](https://github.com/ARMmbed/mbed-tools/issues/282) (282) in the mbed-tools repository by [noonfom](https://github.com/noonfom).
+
+## 📜 License
+The software in this repository is licensed under Apache-2.0. Please refer to [LICENSE](LICENSE) for more information. 
+
+## 🤝 Contributions
+Mbed™ OS is an open-source, device software platform for the Internet of Things. Contributions are an important part of the platform, and our goal is to make it as simple as possible to become a contributor. Contributions to this repository are **greatly appreciated** and accepted under the same Apache-2.0 license. To encourage productive collaboration, as well as robust, consistent and maintainable code, we have a set of guidelines for [contributing to Mbed™ OS](https://os.mbed.com/docs/mbed-os/latest/contributing/index.html).
+
+> **Important**: Please target the `development` branch of this repository for pull requests.
+
+## 👀 Related
+
+* [mbed-os-example-ble](https://github.com/ARMmbed/mbed-os-example-ble)
+* [mbed-os-experimental-ble-services](https://github.com/ARMmbed/mbed-os-experimental-ble-services)
+* [mcuboot](https://github.com/mcu-tools/mcuboot)

--- a/scripts/mcuboot.sh
+++ b/scripts/mcuboot.sh
@@ -180,7 +180,7 @@ mcuboot_build () {
   arm-none-eabi-objcopy -I ihex -O binary signed_update.hex signed_update.bin || \
     fail "Failed to extract binary from elf" "Tip: Check if arm-none-eabi-objcopy is in your path"
 
-  say message "Update binary at $root/MCUboot/target/bootloader/signed_update.hex"
+  say message "Update binary at $root/MCUboot/target/bootloader/signed_update.bin"
   say success "Build Complete" "Please refer to the documentation for demonstration instructions"
 }
 


### PR DESCRIPTION
Please refer to the associated issue (#2) for more information. In summary, the repository's README.md was updated, along with example-specific documentation. The README now offers an overview of the repository (with badges to indicate the build status). Further, it includes documentation of known issues and a short description of the new build tool. 

> **Note**: There was a small change to a say message in mcuboot.sh that indicated the path of the signed update binary.

Closes #2 