### PR TITLE
Resolve CMake Support for MCUboot Example

### DIFF
--- a/MCUboot/target/application/CMakeLists.txt
+++ b/MCUboot/target/application/CMakeLists.txt
@@ -1,0 +1,55 @@
+# Copyright (c) 2021 ARM Limited. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+# Application
+
+cmake_minimum_required(VERSION 3.19.0 FATAL_ERROR)
+
+set(MBED_PATH ${CMAKE_CURRENT_SOURCE_DIR}/mbed-os CACHE INTERNAL "")
+set(EXP_BLE_PATH ${CMAKE_CURRENT_SOURCE_DIR}/mbed-os-experimental-ble-services CACHE INTERNAL "")
+set(MCUBOOT_PATH ${CMAKE_CURRENT_SOURCE_DIR}/mcuboot CACHE INTERNAL "")
+set(MBED_CONFIG_PATH ${CMAKE_CURRENT_BINARY_DIR} CACHE INTERNAL "")
+set(APP_TARGET application)
+
+include(${MBED_PATH}/tools/cmake/app.cmake)
+
+project(${APP_TARGET})
+
+add_subdirectory(${MBED_PATH})
+add_subdirectory(${EXP_BLE_PATH}/services/FOTA)
+add_subdirectory(${MCUBOOT_PATH}/boot/bootutil/)
+add_subdirectory(${MCUBOOT_PATH}/boot/mbed/)  # Mbed-MCUboot Port
+
+include_directories(mbed-os-experimental-ble-services)
+
+add_executable(${APP_TARGET})
+
+project(${APP_TARGET})
+
+target_sources(${APP_TARGET}
+    PRIVATE
+        source/main.cpp
+        source/BlockDeviceFOTAEventHandler.h
+        source/BlockDeviceFOTAEventHandler.cpp
+        source/PeriodicBlockDeviceEraser.cpp
+        source/PeriodicBlockDeviceEraser.h
+)
+
+target_link_libraries(${APP_TARGET}
+    PUBLIC
+        mbed-os
+        mbed-ble
+    	bootutil
+        mbed-events
+    	mbed-mcuboot
+        mbed-storage
+        mbed-mbedtls
+        ble-service-fota
+)
+
+mbed_set_post_build(${APP_TARGET})
+
+option(VERBOSE_BUILD "Have a verbose build process")
+if(VERBOSE_BUILD)
+  set(CMAKE_VERBOSE_MAKEFILE ON)
+endif()

--- a/MCUboot/target/application/mbed-os.lib
+++ b/MCUboot/target/application/mbed-os.lib
@@ -1,1 +1,1 @@
-https://github.com/noonfom/mbed-os/#27160dbe0460ed5c898effbaf8881c39117ba505
+https://github.com/ARMmbed/mbed-os.git

--- a/MCUboot/target/application/mbed_app.json
+++ b/MCUboot/target/application/mbed_app.json
@@ -2,6 +2,11 @@
     "config": {
         "version-number": {
             "value": "\"0.1.0\""
+        },
+        "mbed_app_start": {
+            "help": "Use a custom application start address",
+            "macro_name": "MBED_APP_START",
+            "required": true
         }
     },
     "target_overrides": {
@@ -14,26 +19,24 @@
             "ble-api-implementation.max-characteristic-authorisation-count": 100
         },
         "DISCO_L475VG_IOT01A": {
+            "mbed_app_start": "0x8021000",
             "target.features_add": ["BLE"],
             "cordio.desired-att-mtu": 200,
             "cordio.rx-acl-buffer-size": 204,
-            "target.mbed_app_start": "0x8021000",
             "target.mbed_app_size": "0xBE000",
             "mcuboot.primary-slot-address": "0x8020000",
             "mcuboot.slot-size": "0xC0000",
             "mcuboot.scratch-address": "0x80E0000",
             "mcuboot.scratch-size": "0x20000",
-            "mcuboot.max-img-sectors": "0x180",
-            "mcuboot.read-granularity": 1,
-            "qspif.QSPI_MIN_PROG_SIZE": 1
+            "mcuboot.max-img-sectors": "0x180"
         },
         "NRF52840_DK": {
+            "mbed_app_start": "0x21000",
             "target.features_add": ["BLE"],
             "cordio.desired-att-mtu": 200,
             "cordio.rx-acl-buffer-size": 204,
             "cordio-ll.max-acl-size": 204,
             "cordio-nordic-ll.wsf-pool-buffer-size": 8192,
-            "target.mbed_app_start": "0x21000",
             "target.mbed_app_size": "0xBE000",
             "mcuboot.primary-slot-address": "0x20000",
             "mcuboot.slot-size": "0xC0000",

--- a/MCUboot/target/application/mbed_app.json
+++ b/MCUboot/target/application/mbed_app.json
@@ -11,6 +11,7 @@
     },
     "target_overrides": {
         "*": {
+	    "target.c_lib": "small", 
             "platform.stdio-convert-newlines": true,
             "platform.stdio-baud-rate": 115200,
             "mbed-trace.enable": true,

--- a/MCUboot/target/application/mcuboot.lib
+++ b/MCUboot/target/application/mcuboot.lib
@@ -1,1 +1,1 @@
-https://github.com/mcu-tools/mcuboot/
+https://github.com/lambda-shuttle/mcuboot.git

--- a/MCUboot/target/application/source/main.cpp
+++ b/MCUboot/target/application/source/main.cpp
@@ -27,7 +27,7 @@
 #include "platform/mbed_power_mgmt.h"
 #include "mbed-trace/mbed_trace.h"
 #include "bootutil/bootutil.h"
-#include "secondary_bd.h"
+#include "flash_map_backend/secondary_bd.h"
 
 #define TRACE_GROUP "MAIN"
 

--- a/MCUboot/target/bootloader/CMakeLists.txt
+++ b/MCUboot/target/bootloader/CMakeLists.txt
@@ -1,0 +1,43 @@
+# Copyright (c) 2021 ARM Limited. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+# Bootloader
+
+cmake_minimum_required(VERSION 3.19.0 FATAL_ERROR)
+
+set(MBED_PATH ${CMAKE_CURRENT_SOURCE_DIR}/mbed-os CACHE INTERNAL "")
+set(MCUBOOT_PATH ${CMAKE_CURRENT_SOURCE_DIR}/mcuboot CACHE INTERNAL "")
+set(MBED_CONFIG_PATH ${CMAKE_CURRENT_BINARY_DIR} CACHE INTERNAL "")
+set(APP_TARGET bootloader)
+
+include(${MBED_PATH}/tools/cmake/app.cmake)
+
+project(${APP_TARGET})
+
+add_subdirectory(${MBED_PATH})
+add_subdirectory(${MCUBOOT_PATH}/boot/bootutil/)
+add_subdirectory(${MCUBOOT_PATH}/boot/mbed/)  # Mbed-MCUboot Port
+
+add_executable(${APP_TARGET})
+
+target_sources(${APP_TARGET}
+    PUBLIC
+        default_bd.cpp
+        signing_keys.c
+)
+
+target_link_libraries(${APP_TARGET}
+    PUBLIC
+        bootutil
+        mbed-mcuboot
+        mbed-storage-spif
+        mbed-storage-qspif
+        mbed-baremetal
+)
+
+mbed_set_post_build(${APP_TARGET})
+
+option(VERBOSE_BUILD "Have a verbose build process")
+if(VERBOSE_BUILD)
+    set(CMAKE_VERBOSE_MAKEFILE ON)
+endif()

--- a/MCUboot/target/bootloader/mbed-os.lib
+++ b/MCUboot/target/bootloader/mbed-os.lib
@@ -1,1 +1,1 @@
-https://github.com/noonfom/mbed-os/#27160dbe0460ed5c898effbaf8881c39117ba505
+https://github.com/ARMmbed/mbed-os.git

--- a/MCUboot/target/bootloader/mbed_app.json
+++ b/MCUboot/target/bootloader/mbed_app.json
@@ -10,6 +10,7 @@
         "*": {
             "target.restrict_size": "0x20000",
             "target.c_lib": "small",
+            "target.OUTPUT_EXT": "hex",
             "mcuboot.log-level": "MCUBOOT_LOG_LEVEL_DEBUG",
             "mbed-trace.enable": true,
             "mbed-trace.fea-ipv6": false
@@ -30,9 +31,7 @@
             "mcuboot.slot-size": "0xC0000",
             "mcuboot.scratch-address": "0x80E0000",
             "mcuboot.scratch-size": "0x20000",
-            "mcuboot.max-img-sectors": "0x180",
-            "mcuboot.read-granularity": 1,
-            "qspif.QSPI_MIN_PROG_SIZE": 1
+            "mcuboot.max-img-sectors": "0x180"
         }
     }
 }

--- a/MCUboot/target/bootloader/mcuboot.lib
+++ b/MCUboot/target/bootloader/mcuboot.lib
@@ -1,1 +1,1 @@
-https://github.com/mcu-tools/mcuboot/
+https://github.com/lambda-shuttle/mcuboot.git


### PR DESCRIPTION
Please refer to the associated issue (#3) for more information. In summary, support for building the MCUboot example with the new `mbed-tools` was added; this involved the creation of CMakeLists.txt files and updating the library information for mcuboot. 

> **Note**: The FOTA examples now work on `DISCO_L475VG_IOT01A`; however, the build scripts haven't been updated just yet - this will follow soon.

Closes #3