### PR TITLE
Update FOTA build scripts

### DIFF
--- a/scripts/fota.sh
+++ b/scripts/fota.sh
@@ -22,7 +22,8 @@
 # that requires manual intervention.
 #
 # Important: The tool assumes the target board and toolchain unless otherwise specified by the end-user. However,
-#            currently, the only board and toolchain supported are NRF52840_DK and GCC_ARM respectively.
+#            currently, the only boards and toolchain supported are NRF52840_DK and DISCO_L475VG_IOT01A and GCC_ARM 
+#            respectively.
 
 set -e
 trap 'cleanup $?' SIGINT SIGTERM ERR EXIT
@@ -51,8 +52,9 @@ Options:
   -h, --help                      Print this message and exit
 
 Note:
-  For now, only the NRF52840_DK board and GCC_ARM toolchain are supported. Also,
-  if a mount point isn't provided, then the target binary is not flashed.
+  For now, only the NRF52840_DK and DISCO_L475VG_IOT01A boards and GCC_ARM 
+  toolchain are supported. Also, if a mount point isn't provided, then the 
+  target binary is not flashed.
 EOF
   exit
 }
@@ -114,7 +116,8 @@ valid_example () {
 valid_board () {
   case $board in
     NRF52840_DK) ;;
-    *) fail "Unsupported board" "The only supported board is NRF52840_DK"
+    DISCO_L475VG_IOT01A) ;;
+    *) fail "Unsupported board" "The only supported boards are NRF52840_DK and DISCO_L475VG_IOT01A"
   esac
 }
 

--- a/scripts/fota.sh
+++ b/scripts/fota.sh
@@ -25,7 +25,7 @@
 #            respectively.
 
 set -e
-trap 'cleanup $?' SIGINT SIGTERM ERR
+trap 'cleanup $?' SIGINT SIGTERM ERR EXIT
 
 source scripts/utils.sh
 source scripts/mock.sh

--- a/scripts/mcuboot.sh
+++ b/scripts/mcuboot.sh
@@ -75,21 +75,21 @@ mcuboot_build () {
     mcuboot/scripts/imgtool.py getpub -k signing-keys.pem >> signing_keys.c || \
       fail "Unable to create the signing keys"
 
-  # 7. Build the bootloader using the old mbed-cli
+  # 7. Build the bootloader using mbed-tools
   # Note: This does not silence errors
-  mbed compile -t "$toolchain" -m "$board" || \
+  mbed-tools compile -t "$toolchain" -m "$board" || \
     fail "Failed to compile the bootloader" "Please check the sources"
 
   log success "Created signing keys and built the bootloader"
   log message "Building and signing the primary application..."
 
-  # 8. Build the primary application using the old mbed-cli
+  # 8. Build the primary application using mbed-tools
   # shellcheck disable=SC2015
-  cd "$application" && mbed compile -t "$toolchain" -m "$board" || \
+  cd "$application" && mbed-tools compile -t "$toolchain" -m "$board" || \
     fail "Failed to compile the bootloader" "Please check the sources"
 
   # shellcheck disable=SC2015
-  cp "BUILD/$board/$toolchain/application.hex" "$bootloader" && cd "$bootloader" && \
+  cp "cmake_build/$board/$toolchain/application.hex" "$bootloader" && cd "$bootloader" && \
     mcuboot/scripts/imgtool.py sign -k signing-keys.pem \
     --align 4 -v 0.1.0 --header-size 4096 --pad-header -S 0xC0000 \
     --pad application.hex signed_application.hex || \
@@ -125,7 +125,7 @@ mcuboot_build () {
   log success "Requirements installed/updated"
 
   # 13. Create the factory firmware
-  hexmerge.py -o merged.hex --no-start-addr "BUILD/$board/$toolchain/bootloader.hex" signed_application.hex || \
+  hexmerge.py -o merged.hex --no-start-addr "cmake_build/$board/$toolchain/bootloader.hex" signed_application.hex || \
     fail "Unable to create factory firmware"
 
   # 14. Flash the board with the binary (if skip is 0)
@@ -167,11 +167,11 @@ mcuboot_build () {
   log message "Creating the update binary..."
 
   # shellcheck disable=SC2015
-  cd "$application" && mbed compile -t "$toolchain" -m "$board" || \
+  cd "$application" && mbed-tools compile -t "$toolchain" -m "$board" || \
     fail "Failed to compile the application" "Please check the sources"
 
   # shellcheck disable=SC2015
-  cp "BUILD/$board/$toolchain/application.hex" "$bootloader" && cd "$bootloader" && \
+  cp "cmake_build/$board/$toolchain/application.hex" "$bootloader" && cd "$bootloader" && \
     mcuboot/scripts/imgtool.py sign -k signing-keys.pem \
     --align 4 -v 0.1.1 --header-size 4096 --pad-header -S 0x55000 \
     application.hex signed_update.hex || \
@@ -193,11 +193,11 @@ mcuboot_clean () {
 
   # Remove generated files and folders in bootloader folder
   rm -rf "$bootloader"/sign* "$bootloader/application.hex" "$bootloader/merged.hex"
-  rm -rf "$bootloader/build" "$bootloader/dist" "$bootloader/imgtool.egg-info"
+  rm -rf "$bootloader/cmake_build" "$bootloader/dist" "$bootloader/imgtool.egg-info"
 
   # Remove bootloader dependencies
   rm -rf "$bootloader/mbed-os" "$bootloader/mcuboot"
 
   # Remove application build folder and dependencies
-  rm -rf "$application/BUILD" "$application/mbed-os" "$application/mbed-os-experimental-ble-services" "$application/mcuboot"
+  rm -rf "$application/cmake_build" "$application/mbed-os" "$application/mbed-os-experimental-ble-services" "$application/mcuboot"
 }

--- a/scripts/mcuboot.sh
+++ b/scripts/mcuboot.sh
@@ -26,11 +26,11 @@ prompt_auto_update () {
   done
 }
 
-# Builds the mcuboot example and flashes the binaries if a mount is provided.
+# Builds the mcuboot example and flashes the binaries if -f or --flash is provided
 # Please refer to the commented steps for more information
 # Pre: Arguments passed here are all valid
 mcuboot_build () {
-  toolchain=$1; board=$2; mount=$3; skip=$4; root=$5
+  toolchain=$1; board=$2; skip=$3; root=$4
 
   # Paths to application and bootloader
   application=$root/MCUboot/target/application
@@ -130,7 +130,7 @@ mcuboot_build () {
 
   # 14. Flash the board with the binary (if skip is 0)
   if [[ "$skip" -eq 0 ]]; then
-    pyocd erase --chip && cp merged.hex "$mount" \\
+    pyocd erase --chip && pyocd flash merged.hex \\
       fail "Unable to flash firmware!" "Please ensure the board is connected"
     log success "Factory firmware flashed"
   else

--- a/scripts/mock.sh
+++ b/scripts/mock.sh
@@ -15,11 +15,11 @@
 
 source scripts/utils.sh
 
-# Builds the mock example and flashes the binary if a mount point is provided
+# Builds the mock example and flashes the binary if -f or --flash is provided
 # Please refer to the commented steps for more information
 # Pre: Arguments passed here are all valid
 mock_build () {
-  toolchain=$1; board=$2; mount=$3; skip=$4; root=$5
+  toolchain=$1; board=$2; skip=$3; root=$4
 
   log message "Installing/updating example-specific dependencies..."
   # 1. Install mbed-os and mbed-os experimental-ble-services
@@ -46,15 +46,44 @@ mock_build () {
   arm-none-eabi-objcopy -O binary "$out/BLE_GattServer_FOTAService.elf" "$out/BLE_GattServer_FOTAService.bin" || \
     fail "Failed to extract binary from elf" "Tip: Check if arm-none-eabi-objcopy is in your path"
 
-  # 5. Flash the board with the binary (if skip is 0)
+  # 5. Setup and flash if skip is 0
   # shellcheck disable=SC2015
   if [[ "$skip" -eq 0 ]]; then
-    cp "$out/BLE_GattServer_FOTAService.bin" "$mount" || \
+
+    # 5A. Deactivate the primary virtual environment
+    deactivate
+
+    log message "Creating temporary virtual environment..."
+
+    # 5B. Create a new, temporary virtual environment just for pyocd
+    # shellcheck disable=SC2015
+    mkdir venv && python3 -m venv venv || \
+      fail "Virtual environment creation failed!" "Tip: Check your python installation!"
+
+    # 5C. Activate temporary virtual environment
+    source venv/bin/activate
+
+    log success "Temporary virtual environment activated"
+    log message "Installing requirements (pyocd) silently..."
+
+    # 5D. Install requirements (pyocd and intelhex) for temporary environment (silently)
+    # shellcheck disable=SC2015
+    pip install -q --upgrade pip && pip install -q pyocd==0.30.3 || \
+      fail "Unable to install temporary venv requirements" "Please check scripts/mock.sh"
+
+    log success "Requirements installed/updated"
+
+    # 5E. Flash the board with the binary
+    pyocd flash "$out/BLE_GattServer_FOTAService.bin" || \
       fail "Unable to flash binary!" "Please ensure the board is connected"
     log success "Binary flashed"
+
+    # 5F. Deactivate and restore virtual environment
+    deactivate && rm -rf venv && source "$root/venv/bin/activate"
   else
     log message "Binary at $root/Mock/target/$out/BLE_GattServer_FOTAService.bin"
   fi
+
 
   log success "Build Complete" "Please refer to the documentation for demonstration instructions"
 }


### PR DESCRIPTION
Please refer to the associated issue (#11) for more information. In summary, the build scripts were updated to include the disco board as a viable target option and `pyocd` is now used to flash the target binaries.

Closes #11 